### PR TITLE
Fix & refactor Reed-Solomon; Functionality testing

### DIFF
--- a/src/ligero/data_structures.rs
+++ b/src/ligero/data_structures.rs
@@ -26,9 +26,9 @@ pub struct Ligero<
     D: Digest,
     S: CryptographicSponge,
     P: DenseUVPolynomial<F>,
-    /// one over the rate rho
+    // one over the rate rho
     const rho_inv: usize,
-    /// security parameter, used in calculating t
+    // security parameter, used in calculating t
     const sec_param: usize,
 > {
     pub(crate) _field: PhantomData<F>,

--- a/src/ligero/mod.rs
+++ b/src/ligero/mod.rs
@@ -260,6 +260,9 @@ where
         rng: &mut R,
     ) -> Result<Self::UniversalParams, Self::Error> {
         assert!(rho_inv >= 1, "rho_inv is the inverse of the rate and must be at least 1");
+        // The domain will have size m * rho_inv, but we already have the first m elements
+        GeneralEvaluationDomain::<F>::compute_size_of_domain(max_degree * (rho_inv - 1)).ok_or(Error::UnsupportedDegreeBound(max_degree))?;
+
         Ok(LigeroPCUniversalParams::default())
     }
 

--- a/src/ligero/mod.rs
+++ b/src/ligero/mod.rs
@@ -259,6 +259,7 @@ where
         num_vars: Option<usize>,
         rng: &mut R,
     ) -> Result<Self::UniversalParams, Self::Error> {
+        assert!(rho_inv >= 1, "rho_inv is the inverse of the rate and must be at least 1");
         Ok(LigeroPCUniversalParams::default())
     }
 

--- a/src/ligero/mod.rs
+++ b/src/ligero/mod.rs
@@ -120,9 +120,7 @@ where
         }
 
         // 4. Compute the encoding w = E(v)
-        let fft_domain = GeneralEvaluationDomain::<F>::new(commitment.m).unwrap();
-        let mut domain_iter = fft_domain.elements();
-        let w = reed_solomon(&commitment.proof.v, rho_inv, fft_domain, &mut domain_iter);
+        let w = reed_solomon(&commitment.proof.v, rho_inv);
 
         // 5. Verify the random linear combinations
         for (transcript_index, matrix_index) in indices.into_iter().enumerate() {
@@ -161,13 +159,10 @@ where
         let mat = Matrix::new_from_flat(m, m, &coeffs);
 
         // 2. Apply Reed-Solomon encoding row-wise
-        let fft_domain = GeneralEvaluationDomain::<F>::new(m).unwrap();
-        let mut domain_iter = fft_domain.elements();
-
         let ext_mat = Matrix::new_from_rows(
             mat.rows()
                 .iter()
-                .map(|r| reed_solomon(r, rho_inv, fft_domain, &mut domain_iter))
+                .map(|r| reed_solomon(r, rho_inv))
                 .collect(),
         );
 

--- a/src/ligero/tests.rs
+++ b/src/ligero/tests.rs
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_setup() {
-        let mut rng = &mut test_rng();
+        let rng = &mut test_rng();
         let _ = LigeroPCS::<2>::setup(10, None, rng).unwrap();
 
         // the field we use doesnt have such large domains

--- a/src/ligero/tests.rs
+++ b/src/ligero/tests.rs
@@ -127,9 +127,6 @@ mod tests {
     #[test]
     fn test_reed_solomon() {
         // we use this polynomial to generate the the values we will ask the fft to interpolate
-        // let pol_evals: Vec<F> = to_field(vec![30, 2, 91, 4, 8]);
-        // TODO try for different values of m
-        // for i in 0..16
 
         let rho_inv = 3;
         // `i` is the min number of evaluations we need to interpolate a poly of degree `i - 1`
@@ -165,7 +162,6 @@ mod tests {
 
             // The rest of the elements should agree with the domain
             for j in 0..((rho_inv - 1) * m) {
-                println!("j: {:?}", j);
                 assert_eq!(pol.evaluate(&large_domain.element(j)), encoded[j + m]);
             }
         }

--- a/src/ligero/utils.rs
+++ b/src/ligero/utils.rs
@@ -120,12 +120,6 @@ pub(crate) fn reed_solomon<F: FftField>(
     msg: &[F],
     rho_inverse: usize,
 ) -> Vec<F> {
-    // TODO is this check worth it?
-    // rho_inverse = 0 should never happen; rho_inverse = 1 means no expansion
-    if rho_inverse <= 1 {
-        return msg.to_vec();
-    }
-
     let m = msg.len();
 
     let domain = GeneralEvaluationDomain::<F>::new(m).unwrap();

--- a/src/ligero/utils.rs
+++ b/src/ligero/utils.rs
@@ -1,9 +1,6 @@
 use ark_ff::{FftField, Field, PrimeField};
 
-use ark_poly::{
-    domain::general::GeneralElements, univariate::DensePolynomial, DenseUVPolynomial,
-    EvaluationDomain, GeneralEvaluationDomain, Polynomial,
-};
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_serialize::CanonicalSerialize;
 use digest::Digest;
 use jf_primitives::pcs::transcript::IOPTranscript;
@@ -129,7 +126,7 @@ pub(crate) fn reed_solomon<F: FftField>(
 
     // TODO if rho_inv == 2, then with a systematic encoding the second half will be the same as first - is that an issue?
     let domain = GeneralEvaluationDomain::<F>::new(m * (rho_inverse - 1)).unwrap();
-    let mut encoded = domain.fft(&poly_coeffs);
+    let encoded = domain.fft(&poly_coeffs);
     out.extend_from_slice(&encoded[..((rho_inverse - 1) * m)]);
     out
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Added some checks into the `setup` function (`rho_inv >= 1` ; that there's a large enough FFT domain on our field)
- Fix & change the definition of Reed Solomon utils function: no longer takes in a `domain`. (this particular change is sth we might want to bring back, TBD - but it was easier to test when constructing the domains inside).
- Tests for both of the above
- Tests for commit still failing, but no longer on Reed-Solomon, now on MT construction.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
