### PR TITLE
Copy from `jellyfish` and patch dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ark-serialize = { version = "^0.4.0", default-features = false, features = [ "de
 ark-ff = { version = "^0.4.0", default-features = false }
 ark-ec = { version = "^0.4.0", default-features = false }
 ark-poly = {version = "^0.4.0", default-features = false }
-ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = ["sponge","merkle_tree" ], git = "https://github.com/HungryCatsStudio/crypto-primitives" }
+ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = ["sponge","merkle_tree" ] }
 ark-std = { version = "^0.4.0", default-features = false }
 
 ark-relations = { version = "^0.4.0", default-features = false, optional = true }
@@ -25,7 +25,7 @@ hashbrown = { version = "0.13", default-features = false, optional = true }
 digest = "0.10"
 derivative = { version = "2", features = [ "use_core" ] }
 rayon = { version = "1", optional = true }
-jf-primitives = { version = "0.4.0-pre.0", git = "https://github.com/EspressoSystems/jellyfish/", rev = "6210b1f" }
+merlin = { version = "3.0.0", default-features = false }
 
 [dev-dependencies]
 ark-ed-on-bls12-381 = { version = "^0.4.0", default-features = false }
@@ -52,3 +52,6 @@ std = [ "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-std/std", "ark-relation
 r1cs = [ "ark-relations", "ark-r1cs-std", "hashbrown", "ark-crypto-primitives/r1cs"]
 print-trace = [ "ark-std/print-trace" ]
 parallel = [ "std", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel", "ark-std/parallel", "rayon" ]
+
+[patch.crates-io]
+ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives/", rev = "a0e1e85f4920ea45c0193663798b7732fa119925" }

--- a/src/ligero/data_structures.rs
+++ b/src/ligero/data_structures.rs
@@ -12,12 +12,11 @@ use ark_crypto_primitives::{
 use ark_ff::PrimeField;
 use ark_poly::DenseUVPolynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::borrow::Borrow;
 use ark_std::fmt::Debug;
 use ark_std::marker::PhantomData;
-use digest::Digest;
-use std::borrow::Borrow;
-
 use ark_std::rand::RngCore;
+use digest::Digest;
 
 use super::utils::Matrix;
 use super::utils::{

--- a/src/ligero/data_structures.rs
+++ b/src/ligero/data_structures.rs
@@ -13,9 +13,8 @@ use ark_ff::PrimeField;
 use ark_poly::DenseUVPolynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::fmt::Debug;
-use core::marker::PhantomData;
+use ark_std::marker::PhantomData;
 use digest::Digest;
-use jf_primitives::pcs::transcript::IOPTranscript;
 use std::borrow::Borrow;
 
 use ark_std::rand::RngCore;
@@ -23,6 +22,7 @@ use ark_std::rand::RngCore;
 use super::utils::Matrix;
 use super::utils::{
     calculate_t, compute_dimensions, get_indices_from_transcript, hash_column, reed_solomon,
+    IOPTranscript,
 };
 
 /// The univariate Ligero polynomial commitment scheme based on [[Ligero]][ligero].

--- a/src/ligero/mod.rs
+++ b/src/ligero/mod.rs
@@ -5,11 +5,11 @@ use ark_crypto_primitives::{
 };
 use ark_ff::PrimeField;
 use ark_poly::DenseUVPolynomial;
+use ark_std::borrow::Borrow;
 use ark_std::fmt::Debug;
 use ark_std::marker::PhantomData;
 use ark_std::rand::RngCore;
 use digest::Digest;
-use std::borrow::Borrow;
 
 use crate::data_structures::PCRandomness;
 use crate::ligero::utils::{inner_product, reed_solomon, IOPTranscript};

--- a/src/ligero/mod.rs
+++ b/src/ligero/mod.rs
@@ -6,14 +6,13 @@ use ark_crypto_primitives::{
 use ark_ff::PrimeField;
 use ark_poly::DenseUVPolynomial;
 use ark_std::fmt::Debug;
+use ark_std::marker::PhantomData;
 use ark_std::rand::RngCore;
-use core::marker::PhantomData;
 use digest::Digest;
-use jf_primitives::pcs::transcript::IOPTranscript;
 use std::borrow::Borrow;
 
 use crate::data_structures::PCRandomness;
-use crate::ligero::utils::{inner_product, reed_solomon};
+use crate::ligero::utils::{inner_product, reed_solomon, IOPTranscript};
 use crate::{Error, LabeledCommitment, LabeledPolynomial, PCUniversalParams, PolynomialCommitment};
 
 mod utils;

--- a/src/ligero/utils.rs
+++ b/src/ligero/utils.rs
@@ -2,8 +2,9 @@ use ark_ff::{FftField, Field, PrimeField};
 
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_serialize::CanonicalSerialize;
+use ark_std::marker::PhantomData;
 use digest::Digest;
-use jf_primitives::pcs::transcript::IOPTranscript;
+use merlin::Transcript;
 use rayon::{
     iter::{IntoParallelRefIterator, ParallelIterator},
     prelude::IndexedParallelIterator,
@@ -179,6 +180,86 @@ macro_rules! to_bytes {
         let mut buf = ark_std::vec![];
         ark_serialize::CanonicalSerialize::serialize_compressed($x, &mut buf).map(|_| buf)
     }};
+}
+
+/// The following struct is taken from jellyfish repository. Once they change
+/// their dependency on `crypto-primitive`, we use their crate instead of
+/// a copy-paste. We needed the newer `crypto-primitive` for serializing.
+#[derive(Clone)]
+pub(crate) struct IOPTranscript<F: PrimeField> {
+    transcript: Transcript,
+    is_empty: bool,
+    #[doc(hidden)]
+    phantom: PhantomData<F>,
+}
+
+// TODO: merge this with jf_plonk::transcript
+impl<F: PrimeField> IOPTranscript<F> {
+    /// Create a new IOP transcript.
+    pub(crate) fn new(label: &'static [u8]) -> Self {
+        Self {
+            transcript: Transcript::new(label),
+            is_empty: true,
+            phantom: PhantomData::default(),
+        }
+    }
+
+    /// Append the message to the transcript.
+    pub(crate) fn append_message(&mut self, label: &'static [u8], msg: &[u8]) -> Result<(), Error> {
+        self.transcript.append_message(label, msg);
+        self.is_empty = false;
+        Ok(())
+    }
+
+    /// Append the message to the transcript.
+    pub(crate) fn append_serializable_element<S: CanonicalSerialize>(
+        &mut self,
+        label: &'static [u8],
+        group_elem: &S,
+    ) -> Result<(), Error> {
+        self.append_message(
+            label,
+            &to_bytes!(group_elem).map_err(|_| Error::TranscriptError)?,
+        )
+    }
+
+    /// Generate the challenge from the current transcript
+    /// and append it to the transcript.
+    ///
+    /// The output field element is statistical uniform as long
+    /// as the field has a size less than 2^384.
+    pub(crate) fn get_and_append_challenge(&mut self, label: &'static [u8]) -> Result<F, Error> {
+        //  we need to reject when transcript is empty
+        if self.is_empty {
+            return Err(Error::TranscriptError);
+        }
+
+        let mut buf = [0u8; 64];
+        self.transcript.challenge_bytes(label, &mut buf);
+        let challenge = F::from_le_bytes_mod_order(&buf);
+        self.append_serializable_element(label, &challenge)?;
+        Ok(challenge)
+    }
+
+    /// Generate the challenge from the current transcript
+    /// and append it to the transcript.
+    ///
+    /// Without exposing the internal field `transcript`,
+    /// this is a wrapper around getting bytes as opposed to field elements.
+    pub(crate) fn get_and_append_byte_challenge(
+        &mut self,
+        label: &'static [u8],
+        dest: &mut [u8],
+    ) -> Result<(), Error> {
+        //  we need to reject when transcript is empty
+        if self.is_empty {
+            return Err(Error::TranscriptError);
+        }
+
+        self.transcript.challenge_bytes(label, dest);
+        self.append_message(label, dest)?;
+        Ok(())
+    }
 }
 
 #[inline]

--- a/src/ligero/utils.rs
+++ b/src/ligero/utils.rs
@@ -200,7 +200,7 @@ impl<F: PrimeField> IOPTranscript<F> {
         Self {
             transcript: Transcript::new(label),
             is_empty: true,
-            phantom: PhantomData::default(),
+            phantom: PhantomData,
         }
     }
 


### PR DESCRIPTION
We replaced `IOPtranscript` from `jellyfish` with a copy-paste from them to handle the dependency inconsistency issue for `crypto-primitve`.