### PR TITLE
Aux data

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ let (ck, vk) = PCS::trim(&pp, degree, 2, Some(&[degree])).unwrap();
 
 // 3. PolynomialCommitment::commit
 // The prover commits to the polynomial using their committer key `ck`.
-let (comms, rands) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap(); 
+let (comms, states, rands) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap(); 
 
 let challenge_generator: ChallengeGenerator<<Bls12_377 as Pairing>::ScalarField, Sponge_Bls12_377> = ChallengeGenerator::new_univariate(&mut test_sponge);
 
 // 4a. PolynomialCommitment::open
 // Opening proof at a single point.
-let proof_single = PCS::open(&ck, [&labeled_poly], &comms, &point_1, &mut (challenge_generator.clone()), &rands, None).unwrap(); 
+let proof_single = PCS::open(&ck, [&labeled_poly], &comms, &point_1, &mut (challenge_generator.clone()), &states, &rands, None).unwrap(); 
 
 // 5a. PolynomialCommitment::check
 // Verifying the proof at a single point, given the commitment, the point, the claimed evaluation, and the proof.
@@ -156,6 +156,7 @@ let proof_batched = PCS::batch_open(
    &comms,
    &query_set,
    &mut (challenge_generator.clone()),
+   &states,
    &rands,
    Some(rng),
 ).unwrap();

--- a/bench-templates/src/lib.rs
+++ b/bench-templates/src/lib.rs
@@ -69,7 +69,7 @@ pub fn commit<
         LabeledPolynomial::new("test".to_string(), rand_poly(num_vars, rng), None, None);
 
     let start = Instant::now();
-    let (_, _) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
+    let (_, _, _) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
     start.elapsed()
 }
 
@@ -91,7 +91,7 @@ pub fn commitment_size<
     let labeled_poly =
         LabeledPolynomial::new("test".to_string(), rand_poly(num_vars, rng), None, None);
 
-    let (coms, _) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
+    let (coms, _, _) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
 
     coms[0].commitment().serialized_size(Compress::No)
 }
@@ -114,7 +114,7 @@ where
     let labeled_poly =
         LabeledPolynomial::new("test".to_string(), rand_poly(num_vars, rng), None, None);
 
-    let (coms, randomness) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
+    let (coms, states, randomness) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
     let point = P::Point::rand(rng);
 
     let start = Instant::now();
@@ -124,6 +124,7 @@ where
         &coms,
         &point,
         &mut ChallengeGenerator::new_univariate(&mut test_sponge()),
+        &states,
         &randomness,
         Some(rng),
     )
@@ -148,7 +149,7 @@ where
     let labeled_poly =
         LabeledPolynomial::new("test".to_string(), rand_poly(num_vars, rng), None, None);
 
-    let (coms, randomness) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
+    let (coms, states, randomness) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
     let point = P::Point::rand(rng);
 
     let proofs = PCS::open(
@@ -157,6 +158,7 @@ where
         &coms,
         &point,
         &mut ChallengeGenerator::new_univariate(&mut test_sponge()),
+        &states,
         &randomness,
         Some(rng),
     )
@@ -185,7 +187,7 @@ where
     let labeled_poly =
         LabeledPolynomial::new("test".to_string(), rand_poly(num_vars, rng), None, None);
 
-    let (coms, randomness) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
+    let (coms, states, randomness) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
     let point = P::Point::rand(rng);
     let claimed_eval = labeled_poly.evaluate(&point);
     let proof = PCS::open(
@@ -194,6 +196,7 @@ where
         &coms,
         &point,
         &mut ChallengeGenerator::new_univariate(&mut test_sponge()),
+        &states,
         &randomness,
         Some(rng),
     )

--- a/poly-commit/src/data_structures.rs
+++ b/poly-commit/src/data_structures.rs
@@ -63,6 +63,9 @@ pub trait PCCommitment: Clone + CanonicalSerialize + CanonicalDeserialize {
     fn has_degree_bound(&self) -> bool;
 }
 
+/// Defines the auxiliary data of the commitment
+pub trait PCCommitmentState: Clone + Default + CanonicalSerialize + CanonicalDeserialize {}
+
 /// Defines the minimal interface of prepared commitments for any polynomial
 /// commitment scheme.
 pub trait PCPreparedCommitment<UNPREPARED: PCCommitment>: Clone {

--- a/poly-commit/src/ipa_pc/mod.rs
+++ b/poly-commit/src/ipa_pc/mod.rs
@@ -1,3 +1,4 @@
+use crate::kzg10::CommitmentState;
 use crate::{BTreeMap, BTreeSet, String, ToString, Vec, CHALLENGE_SIZE};
 use crate::{BatchLCProof, DenseUVPolynomial, Error, Evaluations, QuerySet};
 use crate::{LabeledCommitment, LabeledPolynomial, LinearCombination};
@@ -347,6 +348,7 @@ where
     type CommitterKey = CommitterKey<G>;
     type VerifierKey = VerifierKey<G>;
     type Commitment = Commitment<G>;
+    type CommitmentState = CommitmentState;
     type Randomness = Randomness<G>;
     type Proof = Proof<G>;
     type BatchProof = Vec<Self::Proof>;
@@ -418,6 +420,7 @@ where
     ) -> Result<
         (
             Vec<LabeledCommitment<Self::Commitment>>,
+            Vec<Self::CommitmentState>,
             Vec<Self::Randomness>,
         ),
         Self::Error,
@@ -480,7 +483,7 @@ where
         }
 
         end_timer!(commit_time);
-        Ok((comms, rands))
+        Ok((comms, vec![CommitmentState {}; rands.len()], rands))
     }
 
     fn open<'a>(
@@ -489,6 +492,7 @@ where
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         point: &'a P::Point,
         opening_challenges: &mut ChallengeGenerator<G::ScalarField, S>,
+        _states: impl IntoIterator<Item = &'a Self::CommitmentState>,
         rands: impl IntoIterator<Item = &'a Self::Randomness>,
         rng: Option<&mut dyn RngCore>,
     ) -> Result<Self::Proof, Self::Error>
@@ -877,6 +881,7 @@ where
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         query_set: &QuerySet<P::Point>,
         opening_challenges: &mut ChallengeGenerator<G::ScalarField, S>,
+        _states: impl IntoIterator<Item = &'a Self::CommitmentState>,
         rands: impl IntoIterator<Item = &'a Self::Randomness>,
         rng: Option<&mut dyn RngCore>,
     ) -> Result<BatchLCProof<G::ScalarField, Self::BatchProof>, Self::Error>
@@ -972,6 +977,7 @@ where
             lc_commitments.iter(),
             &query_set,
             opening_challenges,
+            &vec![CommitmentState {}; lc_randomness.len()],
             lc_randomness.iter(),
             rng,
         )?;

--- a/poly-commit/src/kzg10/data_structures.rs
+++ b/poly-commit/src/kzg10/data_structures.rs
@@ -329,6 +329,11 @@ pub struct Commitment<E: Pairing>(
     pub E::G1Affine,
 );
 
+/// The auxiliary data for KZG commitment is empty.
+#[derive(Clone, Default, CanonicalSerialize, CanonicalDeserialize)]
+pub struct CommitmentState {}
+impl PCCommitmentState for CommitmentState {}
+
 impl<E: Pairing> PCCommitment for Commitment<E> {
     #[inline]
     fn empty() -> Self {

--- a/poly-commit/src/lib.rs
+++ b/poly-commit/src/lib.rs
@@ -157,7 +157,7 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
     /// The commitment to a polynomial.
     type Commitment: PCCommitment + Default;
     /// The state of committer
-    type CommitterState: Default + CanonicalSerialize + CanonicalDeserialize;
+    type CommitmentState: PCCommitmentState;
     /// The commitment randomness.
     type Randomness: PCRandomness;
     /// The evaluation proof for a single point.
@@ -205,6 +205,7 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
     ) -> Result<
         (
             Vec<LabeledCommitment<Self::Commitment>>,
+            Vec<Self::CommitmentState>,
             Vec<Self::Randomness>,
         ),
         Self::Error,
@@ -219,12 +220,14 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         point: &'a P::Point,
         challenge_generator: &mut ChallengeGenerator<F, S>,
+        states: impl IntoIterator<Item = &'a Self::CommitmentState>,
         rands: impl IntoIterator<Item = &'a Self::Randomness>,
         rng: Option<&mut dyn RngCore>,
     ) -> Result<Self::Proof, Self::Error>
     where
         P: 'a,
         Self::Randomness: 'a,
+        Self::CommitmentState: 'a,
         Self::Commitment: 'a;
 
     /// check but with individual challenges
@@ -255,12 +258,14 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         query_set: &QuerySet<P::Point>,
         challenge_generator: &mut ChallengeGenerator<F, S>,
+        states: impl IntoIterator<Item = &'a Self::CommitmentState>,
         rands: impl IntoIterator<Item = &'a Self::Randomness>,
         rng: Option<&mut dyn RngCore>,
     ) -> Result<Self::BatchProof, Self::Error>
     where
         P: 'a,
         Self::Randomness: 'a,
+        Self::CommitmentState: 'a,
         Self::Commitment: 'a,
     {
         // The default implementation achieves proceeds by rearranging the queries in
@@ -268,11 +273,12 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
         // the same point, then opening their commitments simultaneously with a
         // single call to `open` (per point)
         let rng = &mut crate::optional_rng::OptionalRng(rng);
-        let poly_rand_comm: BTreeMap<_, _> = labeled_polynomials
+        let poly_rand_st_comm: BTreeMap<_, _> = labeled_polynomials
             .into_iter()
+            .zip(states)
             .zip(rands)
             .zip(commitments.into_iter())
-            .map(|((poly, r), comm)| (poly.label(), (poly, r, comm)))
+            .map(|(((poly, st), r), comm)| (poly.label(), (poly, r, st, comm)))
             .collect();
 
         let open_time = start_timer!(|| format!(
@@ -301,19 +307,23 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
         for (_point_label, (point, labels)) in query_to_labels_map.into_iter() {
             let mut query_polys: Vec<&'a LabeledPolynomial<_, _>> = Vec::new();
             let mut query_rands: Vec<&'a Self::Randomness> = Vec::new();
+            let mut query_states: Vec<&'a Self::CommitmentState> = Vec::new();
             let mut query_comms: Vec<&'a LabeledCommitment<Self::Commitment>> = Vec::new();
 
             // Constructing matching vectors with the polynomial, commitment
             // randomness and actual commitment for each polynomial being
             // queried at `point`
             for label in labels {
-                let (polynomial, rand, comm) =
-                    poly_rand_comm.get(label).ok_or(Error::MissingPolynomial {
-                        label: label.to_string(),
-                    })?;
+                let (polynomial, rand, state, comm) =
+                    poly_rand_st_comm
+                        .get(label)
+                        .ok_or(Error::MissingPolynomial {
+                            label: label.to_string(),
+                        })?;
 
                 query_polys.push(polynomial);
                 query_rands.push(rand);
+                query_states.push(state);
                 query_comms.push(comm);
             }
 
@@ -327,6 +337,7 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
                 query_comms,
                 &point,
                 challenge_generator,
+                query_states,
                 query_rands,
                 Some(rng),
             )?;
@@ -440,11 +451,13 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         query_set: &QuerySet<P::Point>,
         challenge_generator: &mut ChallengeGenerator<F, S>,
+        states: impl IntoIterator<Item = &'a Self::CommitmentState>,
         rands: impl IntoIterator<Item = &'a Self::Randomness>,
         rng: Option<&mut dyn RngCore>,
     ) -> Result<BatchLCProof<F, Self::BatchProof>, Self::Error>
     where
         Self::Randomness: 'a,
+        Self::CommitmentState: 'a,
         Self::Commitment: 'a,
         P: 'a,
     {
@@ -466,6 +479,7 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
             commitments,
             &poly_query_set,
             challenge_generator,
+            states,
             rands,
             rng,
         )?;
@@ -717,7 +731,7 @@ pub mod tests {
                 )?;
                 println!("Trimmed");
 
-                let (comms, rands) = PC::commit(&ck, &polynomials, Some(rng))?;
+                let (comms, states, rands) = PC::commit(&ck, &polynomials, Some(rng))?;
 
                 let mut query_set = QuerySet::new();
                 let mut values = Evaluations::new();
@@ -735,6 +749,7 @@ pub mod tests {
                     &comms,
                     &query_set,
                     &mut (challenge_gen.clone()),
+                    &states,
                     &rands,
                     Some(rng),
                 )?;
@@ -850,7 +865,7 @@ pub mod tests {
                 )?;
                 println!("Trimmed");
 
-                let (comms, rands) = PC::commit(&ck, &polynomials, Some(rng))?;
+                let (comms, states, rands) = PC::commit(&ck, &polynomials, Some(rng))?;
 
                 // Construct query set
                 let mut query_set = QuerySet::new();
@@ -871,6 +886,7 @@ pub mod tests {
                     &comms,
                     &query_set,
                     &mut (challenge_gen.clone()),
+                    &states,
                     &rands,
                     Some(rng),
                 )?;
@@ -998,7 +1014,7 @@ pub mod tests {
                 )?;
                 println!("Trimmed");
 
-                let (comms, rands) = PC::commit(&ck, &polynomials, Some(rng))?;
+                let (comms, states, rands) = PC::commit(&ck, &polynomials, Some(rng))?;
 
                 // Let's construct our equations
                 let mut linear_combinations = Vec::new();
@@ -1050,6 +1066,7 @@ pub mod tests {
                     &comms,
                     &query_set,
                     &mut (challenge_gen.clone()),
+                    &states,
                     &rands,
                     Some(rng),
                 )?;

--- a/poly-commit/src/lib.rs
+++ b/poly-commit/src/lib.rs
@@ -156,6 +156,8 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
     type VerifierKey: PCVerifierKey;
     /// The commitment to a polynomial.
     type Commitment: PCCommitment + Default;
+    /// The state of committer
+    type CommitterState: Default + CanonicalSerialize + CanonicalDeserialize;
     /// The commitment randomness.
     type Randomness: PCRandomness;
     /// The evaluation proof for a single point.

--- a/poly-commit/src/marlin/marlin_pst13_pc/mod.rs
+++ b/poly-commit/src/marlin/marlin_pst13_pc/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    kzg10,
+    kzg10::{self, CommitmentState},
     marlin::{marlin_pc, Marlin},
     CHALLENGE_SIZE,
 };
@@ -151,6 +151,7 @@ where
     type CommitterKey = CommitterKey<E, P>;
     type VerifierKey = VerifierKey<E>;
     type Commitment = marlin_pc::Commitment<E>;
+    type CommitmentState = CommitmentState;
     type Randomness = Randomness<E, P>;
     type Proof = Proof<E>;
     type BatchProof = Vec<Self::Proof>;
@@ -343,6 +344,7 @@ where
     ) -> Result<
         (
             Vec<LabeledCommitment<Self::Commitment>>,
+            Vec<Self::CommitmentState>,
             Vec<Self::Randomness>,
         ),
         Self::Error,
@@ -431,7 +433,11 @@ where
             end_timer!(commit_time);
         }
         end_timer!(commit_time);
-        Ok((commitments, randomness))
+        Ok((
+            commitments,
+            vec![CommitmentState {}; randomness.len()],
+            randomness,
+        ))
     }
 
     /// On input a polynomial `p` and a point `point`, outputs a proof for the same.
@@ -441,6 +447,7 @@ where
         _commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         point: &P::Point,
         opening_challenges: &mut ChallengeGenerator<E::ScalarField, S>,
+        _states: impl IntoIterator<Item = &'a Self::CommitmentState>,
         rands: impl IntoIterator<Item = &'a Self::Randomness>,
         _rng: Option<&mut dyn RngCore>,
     ) -> Result<Self::Proof, Self::Error>
@@ -661,6 +668,7 @@ where
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         query_set: &QuerySet<P::Point>,
         opening_challenges: &mut ChallengeGenerator<E::ScalarField, S>,
+        _states: impl IntoIterator<Item = &'a Self::CommitmentState>,
         rands: impl IntoIterator<Item = &'a Self::Randomness>,
         rng: Option<&mut dyn RngCore>,
     ) -> Result<BatchLCProof<E::ScalarField, Self::BatchProof>, Self::Error>

--- a/poly-commit/src/marlin/mod.rs
+++ b/poly-commit/src/marlin/mod.rs
@@ -309,6 +309,7 @@ where
             lc_commitments.iter(),
             &query_set,
             opening_challenges,
+            &vec![PC::CommitmentState::default(); lc_randomness.len()],
             lc_randomness.iter(),
             rng,
         )?;


### PR DESCRIPTION
I added the auxiliary data, the name is `CommitmentState`, since it is a state/data related to each commitment, not to the committer. We can change the name though, I do not like the current name very much.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
