### PR TITLE
Added check length

### DIFF
--- a/poly-commit/src/linear_codes/mod.rs
+++ b/poly-commit/src/linear_codes/mod.rs
@@ -392,6 +392,27 @@ where
         let two_to_one_hash_param: &<<C as Config>::TwoToOneHash as TwoToOneCRHScheme>::Parameters =
             vk.two_to_one_hash_param();
 
+        // We need to collect so that we can both check the lengths and iterate.
+        let commitments: Vec<&LabeledCommitment<Self::Commitment>> =
+            commitments.into_iter().collect();
+        let values: Vec<F> = values.into_iter().collect();
+
+        if commitments.len() != proof_array.len() {
+            return Err(Error::IncorrectInputLength(format!(
+                "commitments {}, but proof_array has length {}",
+                commitments.len(),
+                proof_array.len()
+            )));
+        }
+
+        if commitments.len() != values.len() {
+            return Err(Error::IncorrectInputLength(format!(
+                "commitments {}, but values has length {}",
+                commitments.len(),
+                values.len()
+            )));
+        }
+
         for (i, (labeled_commitment, value)) in commitments.into_iter().zip(values).enumerate() {
             let proof = &proof_array[i];
             let commitment = labeled_commitment.commitment();


### PR DESCRIPTION
`PCS::check` was `zip`ping the commitments, proofs and claimed values. The issue is that `zip` is happy to combine two vectors of unequal length, in which case it drops off the excess elements from the longer vector. This could be dangerous, since `check` fails iff any of the individual proof checks fails, but those checks could be missed.

We considered using `zip_eq`, which panics if the iterators have different length. In the end, we opted for checking the lengths by hand so that we could control the error and return it. Unfortunately, this results in less-than-ideal syntax (but still acceptable), since one can't count an iterator and then iterate over it.

@autquis this is likely also relevant to the Brakedown and Ligero PRs. Let's keep it in mind, even if it's not an urgent fix :)